### PR TITLE
Now results for all 1536 wells are returned

### DIFF
--- a/code/countAmpliconsAWS.R
+++ b/code/countAmpliconsAWS.R
@@ -69,7 +69,7 @@ results <- read_csv("results.csv") %>%
                 index2 = i2) %>% 
   # left_join(bc_map, by = "sequence") %>% 
   mutate(mergedIndex = paste0(index, index2)) %>% 
-  left_join(ss, by = c("mergedIndex","index","index2"))
+  full_join(ss, by = c("mergedIndex","index","index2"))
 
 
 # Check direction of index 1 before merging w/ 384 plate map


### PR DESCRIPTION
When 0 counts were observed for a well, there would be nothing for that sample returned in the LIMS_results.csv file. That has been fixed.